### PR TITLE
enhance: add Add Elements tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/gptscript-ai/datasets/pkg/dataset"
 	"github.com/gptscript-ai/datasets/pkg/tools"
 )
+
+type elementInput struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Content     string `json:"content"`
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -31,10 +39,42 @@ env vars: GPTSCRIPT_WORKSPACE_DIR`)
 		tools.CreateDataset(workspace, os.Getenv("DATASETNAME"), os.Getenv("DATASETDESCRIPTION"))
 	case "addElement":
 		tools.AddElement(workspace, os.Getenv("DATASETID"), os.Getenv("ELEMENTNAME"), os.Getenv("ELEMENTDESCRIPTION"), []byte(os.Getenv("ELEMENTCONTENT")))
+	case "addElements":
+		var elements []elementInput
+		if err := json.Unmarshal([]byte(os.Getenv("ELEMENTS")), &elements); err != nil {
+			fmt.Printf("failed to unmarshal elements: %v\n", err)
+			os.Exit(1)
+		}
+		addElements(workspace, os.Getenv("DATASETID"), elements)
 	case "getAllElements":
 		tools.GetAllElements(workspace, os.Getenv("DATASETID"))
 	default:
 		fmt.Printf("unknown command: %s\n", os.Args[1])
 		os.Exit(1)
 	}
+}
+
+func addElements(workspace, datasetID string, elements []elementInput) {
+	m, err := dataset.NewManager(workspace)
+	if err != nil {
+		fmt.Printf("failed to create dataset manager: %v\n", err)
+		os.Exit(1)
+	}
+
+	d, err := m.GetDataset(datasetID)
+	if err != nil {
+		fmt.Printf("failed to get dataset: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, e := range elements {
+		content := []byte(e.Content)
+		_, err := d.AddElement(e.Name, e.Description, content)
+		if err != nil {
+			fmt.Printf("failed to create element: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("elements added successfully")
 }

--- a/tool.gpt
+++ b/tool.gpt
@@ -29,12 +29,20 @@ Param: datasetDescription: a description of the new dataset
 ---
 Name: Add Element
 Description: Adds a new element to an existing dataset
-Param: elementID: the ID of the dataset
+Param: datasetID: the ID of the dataset
 Param: elementName: the name of the new element
 Param: elementDescription: an optional description of the new element
 Param: elementContent: the data to store in the element
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool addElement
+
+---
+Name: Add Elements
+Description: Adds multiple elements to an existing dataset
+Param: datasetID: the ID of the dataset
+Param: elements: a JSON array of elements to add, like [{"name":"one","description":"element one","contents":"data one"}]
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool addElements
 
 ---
 Name: Get All Elements

--- a/tool.gpt
+++ b/tool.gpt
@@ -40,7 +40,7 @@ Param: elementContent: the data to store in the element
 Name: Add Elements
 Description: Adds multiple elements to an existing dataset
 Param: datasetID: the ID of the dataset
-Param: elements: a JSON array of elements to add, like [{"name":"one","description":"element one","contents":"data one"}]
+Param: elements: a JSON array of elements to add, like [{"name":"one","description":"element one","content":"data one"}]
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool addElements
 


### PR DESCRIPTION
This tool allow for the creation of multiple elements in a dataset at once, which should noticeably improve performance when creating large (i.e. >1000 elements) datasets.

Even though this could replace the old `Add Element` (singular) tool, I'm leaving that here for now, in case there is a future use case where we want an LLM to directly add an element to a dataset. That tool would be easier for it to use, as the arguments are simpler.