### PR TITLE
fix: handle gzip decompression

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,13 +69,11 @@ func handleGzip(elements string) (string, error) {
 		return elements, nil
 	}
 
-	// Base64 decode and gunzip the content
 	decoded, err := base64.StdEncoding.DecodeString(gz.Content)
 	if err != nil {
 		return "", err
 	}
 
-	// unzip it with gzip
 	reader, err := gzip.NewReader(bytes.NewReader(decoded))
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ env vars: GPTSCRIPT_WORKSPACE_DIR`)
 	case "addElements":
 		var err error
 		elements := os.Getenv("ELEMENTS")
-		if strings.Contains(elements, "{\"_gz\":") {
+		if strings.Contains(elements, `{"_gz":`) {
 			elements, err = decompressElements(elements)
 			if err != nil {
 				fmt.Printf("failed to decompress elements: %v\n", err)


### PR DESCRIPTION
It turns out that, if this `ELEMENTS` environment variable is large enough, gptscript will compress it in the format `{"_gz": <base64 string>}`. I'm surprised that I never ran into this before now.