### PR TITLE
fix: maintain order of dataset elements

### DIFF
--- a/pkg/dataset/dataset_test.go
+++ b/pkg/dataset/dataset_test.go
@@ -57,21 +57,32 @@ func TestDatasets(t *testing.T) {
 	metas := dataset.ListElements()
 	require.Len(t, metas, 4)
 
-	oneBytes, _, err := dataset.GetElement(ctx, "file1")
+	oneBytes, oneElement, err := dataset.GetElement(ctx, "file1")
 	require.NoError(t, err)
 	require.Equal(t, "This is dataset file 1.\n", string(oneBytes))
+	require.Equal(t, 0, oneElement.Index)
 
-	twoBytes, _, err := dataset.GetElement(ctx, "file2")
+	twoBytes, twoElement, err := dataset.GetElement(ctx, "file2")
 	require.NoError(t, err)
 	require.Equal(t, "This is dataset file 2.\n", string(twoBytes))
+	require.Equal(t, 1, twoElement.Index)
 
-	threeBytes, _, err := dataset.GetElement(ctx, "file!")
+	threeBytes, threeElement, err := dataset.GetElement(ctx, "file!")
 	require.NoError(t, err)
 	require.Equal(t, "This is dataset file 3.\n", string(threeBytes))
+	require.Equal(t, 2, threeElement.Index)
 
-	fourBytes, _, err := dataset.GetElement(ctx, "file@")
+	fourBytes, fourElement, err := dataset.GetElement(ctx, "file@")
 	require.NoError(t, err)
 	require.Equal(t, "This is dataset file 4.\n", string(fourBytes))
+	require.Equal(t, 3, fourElement.Index)
+
+	// Test to make sure the order was maintained
+	elementMetas := dataset.ListElements()
+	require.Equal(t, "file1", elementMetas[0].Name)
+	require.Equal(t, "file2", elementMetas[1].Name)
+	require.Equal(t, "file!", elementMetas[2].Name)
+	require.Equal(t, "file@", elementMetas[3].Name)
 
 	datasets, err := m.ListDatasets(ctx)
 	require.NoError(t, err)

--- a/pkg/tools/getAllElements.go
+++ b/pkg/tools/getAllElements.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/gptscript-ai/datasets/pkg/dataset"
 )
@@ -24,9 +23,9 @@ func GetAllElements(datasetID string) {
 	}
 
 	elements := d.ListElements()
-	sort.Slice(elements, func(i, j int) bool {
-		return elements[i].Name < elements[j].Name
-	})
+	//sort.Slice(elements, func(i, j int) bool {
+	//	return elements[i].Name < elements[j].Name
+	//})
 
 	var elems []elem
 	for _, e := range elements {

--- a/pkg/tools/getAllElements.go
+++ b/pkg/tools/getAllElements.go
@@ -23,10 +23,6 @@ func GetAllElements(datasetID string) {
 	}
 
 	elements := d.ListElements()
-	//sort.Slice(elements, func(i, j int) bool {
-	//	return elements[i].Name < elements[j].Name
-	//})
-
 	var elems []elem
 	for _, e := range elements {
 		eBytes, _, err := d.GetElement(context.Background(), e.Name)


### PR DESCRIPTION
The implementation of datasets as a map was causing the order to get messed up instead of maintained. This fixes that by adding an `Index` field onto each element.